### PR TITLE
feat(Dockerfile): add python version argument

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
-FROM lambci/lambda:build-python3.7
+ARG python_version=3.7
+
+FROM lambci/lambda:build-python${python_version}
 
 RUN curl -sL https://rpm.nodesource.com/setup_12.x | bash - &&\
     yum install -y nodejs &&\
     npm install -g serverless --unsafe-perm
-


### PR DESCRIPTION
I added a version argument do that we can deploy any kind of python version. What do you think?

If you are happy with the suggestion, please merge and deploy a version with Python 3.9